### PR TITLE
Removed unsupported FQL call

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -74,12 +74,9 @@ get "/" do
 
   if access_token
     @user    = @graph.get_object("me")
-    @friends = @graph.get_connections('me', 'friends')
+    @friends_using_app = @graph.get_connections('me', 'friends')
     @photos  = @graph.get_connections('me', 'photos')
     @likes   = @graph.get_connections('me', 'likes').first(4)
-
-    # for other data you can always run fql
-    @friends_using_app = @graph.fql_query("SELECT uid, name, is_app_user, pic_square FROM user WHERE uid in (SELECT uid2 FROM friend WHERE uid1 = me()) AND is_app_user = 1")
   end
   erb :index
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -177,20 +177,6 @@
     <section id="samples" class="clearfix">
           <h1>Examples of the Facebook Graph API</h1>
 
-          <div class="list">
-            <h3>A few of your friends</h3>
-            <ul class="friends">
-              <% @friends.each do |friend| %>
-                <li>
-                  <a href="#" onclick="window.open('http://www.facebook.com/<%= friend['id']%>')">
-                    <img src="https://graph.facebook.com/<%= friend['id'] %>/picture?type=square" alt="<%= friend['name'] %>">
-                    <%= friend['name'] %>
-                  </a>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-
           <div class="list inline">
             <h3>Recent photos</h3>
             <ul class="photos">


### PR DESCRIPTION
Facebook API no longer supports FQL and only allows retrieving friends
who are also app users.